### PR TITLE
fix Bb2 being displayed as Ab2 on the chart

### DIFF
--- a/src/utils/notes.ts
+++ b/src/utils/notes.ts
@@ -150,7 +150,7 @@ export const flats: INote[] = [
     {
         note: "B♭",
         octave: 2,
-        notation: "_A,",
+        notation: "_B,",
     },
     {
         note: "G♭",


### PR DESCRIPTION
One more little fix. One of the notes in the original 4-string notes array was off. I'm surprised no one caught it before, I've started to question reality when it refused to accept me playing Ab over it haha!

![Screenshot 2025-02-22 224441](https://github.com/user-attachments/assets/e5366398-60f4-489c-a2c6-0977765d3d07)
