### PR TITLE
Key signatures update

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -55,6 +55,7 @@ export const App: React.FC = () => {
 	};
 
 	const reset = () => {
+		// TODO: Implement handling a random key option
 		setCount(1);
 		setNotesToPlay(getRandomNotes(4, options));
 	};

--- a/src/components/MusicStaff.tsx
+++ b/src/components/MusicStaff.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from "react";
 import { rest, naturals, sharps, flats } from "../utils/notes";
 import { EShowLabels, INote, IOptions } from "./../utils/types";
+import { applyAccidentalToAbcNotatedNote, getAccidentalCharacterToRender } from "./../utils/helpers";
 import abcjs from "abcjs";
 
 interface Props {
@@ -37,22 +38,27 @@ export const MusicStaff: React.FC<Props> = (props) => {
 
     const renderNotation = (notes: INote[], key: string) => {
         let notation = `K: ${key.replace("♯", "#").replace("♭", 'b')} \n`;
+        let previousNotes: INote[] = [];
         notes?.forEach((note, index) => {
+            const printableAccidentalCharacter = getAccidentalCharacterToRender(note.note, options.key, previousNotes);
+            const noteAbcNotationToRender = applyAccidentalToAbcNotatedNote(note.notation, printableAccidentalCharacter);
+            previousNotes.push(note);
+
             if (index < count && userAudio ) {
                 switch (options.showLabels) {
                     case EShowLabels.ALWAYS:
-                        notation += `\"_${ note.note }${ options.detectOctaves ? note.octave : "" }\"${ note.notation }`;
+                        notation += `\"_${ note.note }${ options.detectOctaves ? note.octave : "" }\"${ noteAbcNotationToRender }`;
                         break;
                     case EShowLabels.WHENCORRECT:
-                        notation += index + 1 != count ? `\"_${ note.note }${ options.detectOctaves ? note.octave : "" }\"${ note.notation }` : `\"_?\"${ note.notation }`;
+                        notation += index + 1 != count ? `\"_${ note.note }${ options.detectOctaves ? note.octave : "" }\"${ noteAbcNotationToRender }` : `\"_?\"${ noteAbcNotationToRender }`;
                         break;
                     case EShowLabels.NEVER:
-                        notation += note.notation;
+                        notation += noteAbcNotationToRender;
                 }
             } else if (userAudio) {
                 notation += rest.notation;
             } else {
-                notation += note.notation;
+                notation += noteAbcNotationToRender;
             }
         });
 

--- a/src/components/MusicStaff.tsx
+++ b/src/components/MusicStaff.tsx
@@ -26,7 +26,7 @@ export const MusicStaff: React.FC<Props> = (props) => {
     const displayNotes = [ sharps[1], naturals[6], flats[2], naturals[6] ];
 
     useEffect(() => {
-        abcjs.renderAbc(div.current, bar + renderNotation(notesToPlay ?? displayNotes), {
+        abcjs.renderAbc(div.current, bar + renderNotation(notesToPlay ?? displayNotes, options.key), {
             add_classes: true,
             responsive: "resize",
             staffwidth: 200,
@@ -35,8 +35,8 @@ export const MusicStaff: React.FC<Props> = (props) => {
         if (el) el.style.color = "#141414";
     }, [ notesToPlay, count ]);
 
-    const renderNotation = (notes: INote[]) => {
-        let notation = "";
+    const renderNotation = (notes: INote[], key: string) => {
+        let notation = `K: ${key.replace("♯", "#").replace("♭", 'b')} \n`;
         notes?.forEach((note, index) => {
             if (index < count && userAudio ) {
                 switch (options.showLabels) {

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -61,22 +61,28 @@ export const Options: React.FC<Props> = (props) => {
 						</div>
 						<div className="button-group">
 							<button
-								className={ `${options.accidentals.includes(EAccidentals.NATURALS) ? `active` : ``}` }
-								onClick={ () => dispatchOptions({ type: "toggleAccidental", accidental: EAccidentals.NATURALS }) }
+								className={ `${options.accidentals.includes(EAccidentals.NONE) ? `active` : ``}` }
+								onClick={ () => dispatchOptions({ type: "toggleAccidental", accidental: EAccidentals.NONE }) }
 							>
-								Naturals
+								♪
 							</button>
 							<button
 								className={ `${options.accidentals.includes(EAccidentals.SHARPS) ? `active` : ``}` }
 								onClick={ () => dispatchOptions({ type: "toggleAccidental", accidental: EAccidentals.SHARPS }) }
 							>
-								Sharps
+								♪♯
 							</button>
 							<button
 								className={ `${options.accidentals.includes(EAccidentals.FLATS) ? `active` : ``}` }
 								onClick={ () => dispatchOptions({ type: "toggleAccidental", accidental: EAccidentals.FLATS }) }
 							>
-								Flats
+								♪♭
+							</button>
+							<button
+								className={ `${options.accidentals.includes(EAccidentals.NATURALS) ? `active` : ``}` }
+								onClick={ () => dispatchOptions({ type: "toggleAccidental", accidental: EAccidentals.NATURALS }) }
+							>
+								♪♮
 							</button>
 						</div>
 					</div>

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { EShowLabels, IOptions, EAccidentals, EExtendedRange, Action, EModal, } from "./../utils/types";
+import { printableKeySignatures } from "./../utils/helpers";
 import { TiTimes } from "react-icons/ti";
 
 interface Props {
@@ -77,6 +78,23 @@ export const Options: React.FC<Props> = (props) => {
 							>
 								Flats
 							</button>
+						</div>
+					</div>
+
+					<div className="option">
+						<div className="label">
+							<h2>Key signature</h2>
+							<p>Display clef in a specific key signature, or have a random key every bar.</p>
+						</div>
+						<div className="dropdown">
+							<select
+								value={options.key || "C major / A minor (no sharps or flats)"}
+								onChange={(e) => dispatchOptions({ type: "changeKey", key: e.target.value })}
+							>
+								{Object.entries(printableKeySignatures).map(([label, value]) => (
+									<option key={value} value={value} label={label}/>
+								))}
+							</select>
 						</div>
 					</div>
 

--- a/src/reducers/optionsReducer.ts
+++ b/src/reducers/optionsReducer.ts
@@ -5,6 +5,7 @@ export const initialOptions: IOptions = {
   showLabels: EShowLabels.WHENCORRECT,
   detectOctaves: false,
   extendedRanges: [],
+  key: "C major",
 };
 
 export const optionsReducer = (state: IOptions, action: Action) => {
@@ -37,6 +38,13 @@ export const optionsReducer = (state: IOptions, action: Action) => {
         return {
             ...state,
             extendedRanges: extendedRanges,
+        };
+    }
+    case "changeKey": {
+      console.debug("Change key, " + action.key)
+        return {
+            ...state,
+            key: action.key,
         };
     }
   }

--- a/src/reducers/optionsReducer.ts
+++ b/src/reducers/optionsReducer.ts
@@ -41,7 +41,6 @@ export const optionsReducer = (state: IOptions, action: Action) => {
         };
     }
     case "changeKey": {
-      console.debug("Change key, " + action.key)
         return {
             ...state,
             key: action.key,

--- a/src/reducers/optionsReducer.ts
+++ b/src/reducers/optionsReducer.ts
@@ -1,7 +1,7 @@
 import { EAccidentals, EShowLabels, IOptions, Action } from "../utils/types";
 
 export const initialOptions: IOptions = {
-  accidentals: [ EAccidentals.NATURALS ],
+  accidentals: [ EAccidentals.NONE ],
   showLabels: EShowLabels.WHENCORRECT,
   detectOctaves: false,
   extendedRanges: [],

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -241,6 +241,25 @@ button.active {
 	color: $white;
 }
 
+select {
+    font-family: $font-sans;
+	text-transform: uppercase;
+	font-weight: 600;
+    font-size: 1rem;
+    background-color: $white;
+    color: $black;
+    border: 2px solid $black;
+    padding: 0.4rem 1rem;
+    border-radius: 0.125rem;
+    cursor: pointer;
+    transition: background-color 300ms, color 300ms;
+
+    &:hover {
+        background-color: $brand;
+        color: $white;
+    }
+}
+
 .icon {
 	font-size: 2.75rem;
 	cursor: pointer;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -41,49 +41,53 @@ export const frequencyToNote = (freq: number | null): INote | null => {
     };
 };
 
+let previousNote: INote = naturals[0];
+
 export const getRandomNotes = (n: number, options: IOptions): INote[] => {
+    let timeoutLimit: number = 128;
     let notePool: INote[] = [];
     const randomNotes: INote[] = [];
 
-    options.accidentals?.forEach(accidental => {
-        switch (accidental) {
-            case EAccidentals.SHARPS:
-                notePool = notePool.concat(sharps);
-                options.extendedRanges.forEach(extendedRange => {
-                    notePool = notePool.concat(
-                        (extendedRange === EExtendedRange.LOWB) ? sharpsExtendedLow : sharpsExtendedHigh
-                    );
-                });
-                break;
+    notePool = notePool.concat(sharps);
+    notePool = notePool.concat(flats);
+    notePool = notePool.concat(naturals);
 
-            case EAccidentals.FLATS:
-                notePool = notePool.concat(flats);
-                options.extendedRanges.forEach(extendedRange => {
-                    notePool = notePool.concat(
-                        (extendedRange === EExtendedRange.LOWB) ? flatsExtendedLow : flatsExtendedHigh
-                    );
-                });
-                break;
-
-            case EAccidentals.NATURALS:
-                notePool = notePool.concat(naturals);
-                options.extendedRanges.forEach(extendedRange => {
-                    notePool = notePool.concat(
-                        (extendedRange === EExtendedRange.LOWB) ? naturalsExtendedLow : naturalsExtendedHigh
-                    );
-                });
-                break;
-        }
+    options.extendedRanges.forEach(extendedRange => {
+        notePool = notePool.concat((extendedRange === EExtendedRange.LOWB) ? sharpsExtendedLow : sharpsExtendedHigh);
+        notePool = notePool.concat((extendedRange === EExtendedRange.LOWB) ? flatsExtendedLow : flatsExtendedHigh);
+        notePool = notePool.concat((extendedRange === EExtendedRange.LOWB) ? naturalsExtendedLow : naturalsExtendedHigh);
     });
 
-    if (notePool?.length === 0) notePool = naturals;
+    if (notePool?.length == 0)
+        throw new Error('No notes to pick from!');
 
     while (randomNotes.length < n) {
         const randomInt = randomIntFromInterval(0, notePool.length - 1);
         const randomNote = notePool[randomInt];
-        if (!randomNotes.find(x => x.note === randomNote.note)) {
-            randomNotes.push(notePool[randomInt]);
+        const isDuplicateNote: boolean = options.detectOctaves ? (randomNote === previousNote) : (randomNote.note === previousNote.note);
+
+        if (isDuplicateNote)
+            continue;
+
+        for (let accidental of options.accidentals) {
+            if ((getAccidentalCharacterToRender(randomNote.note, options.key, randomNotes) == "" && accidental === EAccidentals.NONE)
+                || (getAccidentalCharacterToRender(randomNote.note, options.key, randomNotes) == "♯" && accidental === EAccidentals.SHARPS)
+                || (getAccidentalCharacterToRender(randomNote.note, options.key, randomNotes) == "♭" && accidental === EAccidentals.FLATS)
+                || (getAccidentalCharacterToRender(randomNote.note, options.key, randomNotes) == "♮" && accidental === EAccidentals.NATURALS)){
+                    randomNotes.push(randomNote);
+                    previousNote = randomNote;
+                    break;
+                }
         }
+
+        // FIXME: In some unfortunate combination of key signature, "Accidentals" settings and previous note,
+        // the next note might be impossible to generate. Come up with some time-out behaviour.
+        if (--timeoutLimit === 0)
+        {
+            console.debug("Could not generate enough notes");
+            break;
+        }
+
     }
 
     return randomNotes;
@@ -133,16 +137,61 @@ const keys: Record<string, string[]> = {
     "A♭ minor": ["A♭", "B♭", "C♭", "D♭", "E♭", "F♭", "G♭"],
 };
 
-const validNotes = new Set<string>([
-    "C", "D", "E", "F", "G", "A", "B",
-    "C♯", "D♯", "E♯", "F♯", "G♯", "A♯", "B♯",
-    "C♭", "D♭", "E♭", "F♭", "G♭", "A♭", "B♭"
-]);
+const removeAccidental = (note: string): string => {
+    return note.replace("♯", "").replace("♭", "").replace("♮", "");
+}
 
-export const isInKey = (note: string, key: string): boolean => {
-    if (!(key in keys)) throw new Error(`Invalid key: ${key}`);
-    if (!validNotes.has(note)) throw new Error(`Invalid note: ${note}`);
-    return keys[key].includes(note);
+const getNoteAccidental = (note: string): string => {
+    return note.slice(1);
+}
+
+const abcAccidentals: Record<string, string> ={
+    "": "",
+    "♯": "^",
+    "♭": "_",
+    "♮": "=",
+}
+
+export const applyAccidentalToAbcNotatedNote = (abcNotatedNote: string, printableAccidentalCharacter: string): string => {
+    const abcAccidentalCharacter = abcAccidentals[printableAccidentalCharacter];
+    return abcAccidentalCharacter + abcNotatedNote.replace("_", "").replace("^", "");
+};
+
+export const getAccidentalCharacterToRender = (note: string, key: string, previousNotes: INote[]): string => {
+    if (previousNotes?.length > 3)
+        throw new Error('Unexpected amount of notes in the bar: ' + previousNotes?.length);
+        //console.debug ('Unexpected amount of notes in the bar: ' + previousNotes?.length);
+
+    let accidentalState = "";
+
+    // The key will give us the initial state of accidental character
+    for (let noteInScale of keys[key]) {
+        if (removeAccidental (noteInScale) != removeAccidental(note))
+            continue;
+
+        accidentalState = getNoteAccidental(noteInScale);
+        break;
+    }
+
+    // Figure out the state of accidental for a given note by the end of previousNotes sequence
+    for (let previousNote of previousNotes)
+    {
+        if (removeAccidental (previousNote.note) != removeAccidental(note))
+            continue;
+
+        accidentalState = getNoteAccidental(previousNote.note);
+    }
+
+    // No accidental or accidental is already marked
+    if (accidentalState === getNoteAccidental(note))
+        return "";
+
+    // Current note is natural, but an accidental was previously applied
+    if (getNoteAccidental(note) === '')
+        return "♮";
+
+    // Note's accidental needs to be applied
+    return getNoteAccidental(note);
 };
 
 export const printableKeySignatures: Record<string, string> = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -99,3 +99,67 @@ export const notesAreEqual = (notePlaying: INote, noteToCheck: INote, options: I
         return equalNote;
     }
 };
+
+const keys: Record<string, string[]> = {
+    "C major": ["C", "D", "E", "F", "G", "A", "B"],
+    "G major": ["G", "A", "B", "C", "D", "E", "F♯"],
+    "D major": ["D", "E", "F♯", "G", "A", "B", "C♯"],
+    "A major": ["A", "B", "C♯", "D", "E", "F♯", "G♯"],
+    "E major": ["E", "F♯", "G♯", "A", "B", "C♯", "D♯"],
+    "B major": ["B", "C♯", "D♯", "E", "F♯", "G♯", "A♯"],
+    "F♯ major": ["F♯", "G♯", "A♯", "B", "C♯", "D♯", "E♯"],
+    "C♯ major": ["C♯", "D♯", "E♯", "F♯", "G♯", "A♯", "B♯"],
+    "F major": ["F", "G", "A", "B♭", "C", "D", "E"],
+    "B♭ major": ["B♭", "C", "D", "E♭", "F", "G", "A"],
+    "E♭ major": ["E♭", "F", "G", "A♭", "B♭", "C", "D"],
+    "A♭ major": ["A♭", "B♭", "C", "D♭", "E♭", "F", "G"],
+    "D♭ major": ["D♭", "E♭", "F", "G♭", "A♭", "B♭", "C"],
+    "G♭ major": ["G♭", "A♭", "B♭", "C♭", "D♭", "E♭", "F"],
+    "C♭ major": ["C♭", "D♭", "E♭", "F♭", "G♭", "A♭", "B♭"],
+    "A minor": ["A", "B", "C", "D", "E", "F", "G"],
+    "E minor": ["E", "F♯", "G", "A", "B", "C", "D"],
+    "B minor": ["B", "C♯", "D", "E", "F♯", "G", "A"],
+    "F♯ minor": ["F♯", "G♯", "A", "B", "C♯", "D", "E"],
+    "C♯ minor": ["C♯", "D♯", "E", "F♯", "G♯", "A", "B"],
+    "G♯ minor": ["G♯", "A♯", "B", "C♯", "D♯", "E", "F♯"],
+    "D♯ minor": ["D♯", "E♯", "F♯", "G♯", "A♯", "B", "C♯"],
+    "A♯ minor": ["A♯", "B♯", "C♯", "D♯", "E♯", "F♯", "G♯"],
+    "D minor": ["D", "E", "F", "G", "A", "B♭", "C"],
+    "G minor": ["G", "A", "B♭", "C", "D", "E♭", "F"],
+    "C minor": ["C", "D", "E♭", "F", "G", "A♭", "B♭"],
+    "F minor": ["F", "G", "A♭", "B♭", "C", "D♭", "E♭"],
+    "B♭ minor": ["B♭", "C", "D♭", "E♭", "F", "G♭", "A♭"],
+    "E♭ minor": ["E♭", "F", "G♭", "A♭", "B♭", "C♭", "D♭"],
+    "A♭ minor": ["A♭", "B♭", "C♭", "D♭", "E♭", "F♭", "G♭"],
+};
+
+const validNotes = new Set<string>([
+    "C", "D", "E", "F", "G", "A", "B",
+    "C♯", "D♯", "E♯", "F♯", "G♯", "A♯", "B♯",
+    "C♭", "D♭", "E♭", "F♭", "G♭", "A♭", "B♭"
+]);
+
+export const isInKey = (note: string, key: string): boolean => {
+    if (!(key in keys)) throw new Error(`Invalid key: ${key}`);
+    if (!validNotes.has(note)) throw new Error(`Invalid note: ${note}`);
+    return keys[key].includes(note);
+};
+
+export const printableKeySignatures: Record<string, string> = {
+    "Random": "Random",
+    "C major / A minor (no sharps or flats)": "C major",
+    "G major / E minor (♯)": "G major",
+    "D major / B minor (♯♯)": "D major",
+    "A major / F♯ minor (♯♯♯)": "A major",
+    "E major / C♯ minor (♯♯♯♯)": "E major",
+    "B major / G♯ minor (♯♯♯♯♯)": "B major",
+    "F♯ major / D♯ minor (♯♯♯♯♯♯)": "F♯ major",
+    "C♯ major / A♯ minor (♯♯♯♯♯♯♯)": "C♯ major",
+    "F major / D minor (♭)": "F major",
+    "B♭ major / G minor (♭♭)": "B♭ major",
+    "E♭ major / C minor (♭♭♭)": "E♭ major",
+    "A♭ major / F minor (♭♭♭♭)": "A♭ major",
+    "D♭ major / B♭ minor (♭♭♭♭♭)": "D♭ major",
+    "G♭ major / E♭ minor (♭♭♭♭♭♭)": "G♭ major",
+    "C♭ major / A♭ minor (♭♭♭♭♭♭♭)": "C♭ major"
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -41,6 +41,12 @@ export const frequencyToNote = (freq: number | null): INote | null => {
     };
 };
 
+const isDuplicateNote = (note1: INote, note2: INote, ignoreOctave: boolean): boolean => {
+    const unisonOrOctave: boolean = (note1.note === note2.note) || (note1.note === transpose(note2.note));
+    const sameOctave: boolean = (note1.octave === note2.octave);
+    return ignoreOctave ? unisonOrOctave : (unisonOrOctave && sameOctave);
+}
+
 let previousNote: INote = naturals[0];
 
 export const getRandomNotes = (n: number, options: IOptions): INote[] => {
@@ -64,9 +70,8 @@ export const getRandomNotes = (n: number, options: IOptions): INote[] => {
     while (randomNotes.length < n) {
         const randomInt = randomIntFromInterval(0, notePool.length - 1);
         const randomNote = notePool[randomInt];
-        const isDuplicateNote: boolean = options.detectOctaves ? (randomNote === previousNote) : (randomNote.note === previousNote.note);
 
-        if (isDuplicateNote)
+        if (isDuplicateNote (randomNote, previousNote, !options.detectOctaves))
             continue;
 
         for (let accidental of options.accidentals) {
@@ -87,7 +92,6 @@ export const getRandomNotes = (n: number, options: IOptions): INote[] => {
             console.debug("Could not generate enough notes");
             break;
         }
-
     }
 
     return randomNotes;
@@ -137,6 +141,11 @@ const keys: Record<string, string[]> = {
     "A♭ minor": ["A♭", "B♭", "C♭", "D♭", "E♭", "F♭", "G♭"],
 };
 
+export const getRandomKey = (): string => {
+    const keyNames = Object.keys(keys);
+    return keyNames[randomIntFromInterval(0, keyNames.length - 1)];
+};
+
 const removeAccidental = (note: string): string => {
     return note.replace("♯", "").replace("♭", "").replace("♮", "");
 }
@@ -160,7 +169,6 @@ export const applyAccidentalToAbcNotatedNote = (abcNotatedNote: string, printabl
 export const getAccidentalCharacterToRender = (note: string, key: string, previousNotes: INote[]): string => {
     if (previousNotes?.length > 3)
         throw new Error('Unexpected amount of notes in the bar: ' + previousNotes?.length);
-        //console.debug ('Unexpected amount of notes in the bar: ' + previousNotes?.length);
 
     let accidentalState = "";
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -9,6 +9,7 @@ export interface IOptions {
     showLabels: EShowLabels;
     detectOctaves: boolean;
     extendedRanges: EExtendedRange[];
+    key: string;
 }
 
 export enum EModal {
@@ -22,6 +23,7 @@ export type Action =
      | { type: "showLabels", label: EShowLabels }
      | { type: "detectOctaves", octave: boolean }
      | { type: "toggleExtendedRange", extendedRange: EExtendedRange }
+     | { type: "changeKey", key: string }
 
 export enum EAccidentals {
      SHARPS = "Sharps",

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,6 +29,7 @@ export enum EAccidentals {
      SHARPS = "Sharps",
      FLATS = "Flats",
      NATURALS = "Naturals",
+     NONE = "None",
 }
 
 export enum EShowLabels {


### PR DESCRIPTION
Hi Des! I believe this pretty much solves #3.

Things to mention:

1. Not there's 4 options for accidentals, since now naturals can either be just note, or a note with a "♮" applied. Default is just note with no extra marks.
2. Unrelated to the feature, but I've changed the way duplicate note are skipped, while I was at it. Now there can be two duplicate notes in the bar as long as they aren't in a row. And it handles pairs like G#/Ab correctly now, takes into account "Detect octaves" option, and handles pairs consisting of 4th beat or previous bar and 1st beat of current one. I think this way it makes more sense.
3. It follows common notation practice, where if, say, there's two C#'s in a C major key in a bar, it only marks first one with a #, and then those accidentals get reset at the start of next bar. Required a bit more complicated logic, but I think it was worth it.

Things to address before moving it to prod:

1. There's a LOT more stuff to test now, and I haven't tested it rigorously. I just spend my current reading practice time as testing. But so far everything odd I've encountered has been fixed. Ideally some automated tests would be appropriate to keep us sane. Or some volunteers to test it manually, from Reddit or something :D
2. There can be some option combinations where you can't generate even a single bar. Easiest example is "E minor" key with only "♮" selected in "Accidentals" setting. Would be a good idea to address somehow, perhaps at the front end.
3. Some valid option combinations may paint them self into a corner, by starting a sequence they can't finish... I think. Like, it can run out of notes that require certain accidentals if it started with a few specific notes in a specific key. Can't give you an example, but I feel like it might happen. In this case ```getRandomNotes()``` should just start over, but at the moment it doesn't do it.
4. It doesn't handle "Random" key option yet. I've just realized both back end (```getRandomNotes()```) and front end (```MusicStaff()```) should be aware of what this random key is at any moment. Do you think we should store the current random key somewhere in the app's state, along with ```options``` and other stuff?
5. Since I wanted to skip duplicate notes when 1st one in the bar is the same as 4th one in the previous bar, I made a global ```previousNote``` var, but it bugs me a little. Do you think there's a more elegant way to store it? Should we put it somewhere beside the random key from my previous point?
6. I didn't worry too much about how new settings look, just AI generated some CSS style for dropdown to match other elements and called it a day. It doesn't match exactly (larger font, I think and a hover effect). And also accidental buttons are to small, but I'd probably prefer to replace them with some pretty SVG's with quarter notes, what do you think?

Have to admit, manually testing all this gave me lot of extra reading practice, I've almost become better at reading bass cleff haha!